### PR TITLE
Add options to ignore element's ID

### DIFF
--- a/__tests__/test.spec.ts
+++ b/__tests__/test.spec.ts
@@ -45,6 +45,14 @@ describe( 'getXPath', () => {
         expect( r ).toEqual( '//*[@id="foo"]' );
     } );
 
+    it( 'element with id and ignoreId options is on', () => {
+        const e = document.createElement( 'span' );
+        e.id = 'foo'
+        document.body.appendChild( e );
+        const r = getXPath( e , {ignoreId: true});
+        expect( r ).toEqual( '/html/body/span' );
+    } );
+
     it( 'single leaf element', () => {
         const e1 = document.createElement( 'div' );
         const e2 = document.createElement( 'span' );

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ npm i get-xpath
 ## API
 
 ```typescript
-function getXPath( element: HTMLElement ): string;
+function getXPath( element: HTMLElement, options?: Partial<Options> ): string;
 ```
 
 ## Usage
@@ -30,6 +30,13 @@ function getXPath( element: HTMLElement ): string;
 - On [Node](https://nodejs.org/) or [Deno](https://deno.land/), you have to provide a way to accessing or emulating the DOM.
 You can use [JSDOM](https://github.com/jsdom/jsdom) (or any other library) for that.
 - When using TypeScript, add the value `"dom"` to the property `"lib"`of your `tsconfig.json`. Otherwise you will probably get errors.
+
+## Options
+
+| name       | type    | description                          |
+|------------|---------|--------------------------------------|
+| `ignoreId` | boolean | Do not take elements ID into account |
+
 
 ### Browser
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
+export type Options = {
+    ignoreId: boolean
+}
 
-export default function getXPath(el: any): string {
+const defaultOptions: Options = {
+    ignoreId: false
+}
+
+export default function getXPath(el: any, customOptions?: Partial<Options>): string {
+    const options = {...defaultOptions, ...customOptions}
     let nodeElem = el;
-    if (nodeElem && nodeElem.id) {
+    if (nodeElem && nodeElem.id && !options.ignoreId) {
         return "//*[@id=\"" + nodeElem.id + "\"]";
     }
     let parts: string[] = [];


### PR DESCRIPTION
This might be a particular need of our team, but we need to be able to ignore the IDs of the elements in the `dom`. 

This PR adds an optional argument `options` to `getXPath`, enabling to ignore the node's ID:

```
getXPath(element) // returns '//*[@id="foo"]'
getXPath(element, { ignoreId: true }) // returns '/html/body/span' 
```

It was designed so that if new options are needed, this should be fairly easy to extend.